### PR TITLE
Add OBJECT_FILES to compile-config

### DIFF
--- a/compile-config
+++ b/compile-config
@@ -1,3 +1,4 @@
 GXX="/usr/bin/g++"
+OBJECT_FILES="crt1.o crti.o crtn.o crtbegin.o crtend.o libgcc.a libgcc_s.so libstdc++.so libstdc++.so.6 libmcheck.a libc.so libc_nonshared.a libm.so libm.so.6 libc.so.6 libgcc_s.so.1"
 COMPILE_FLAGS="-finput-charset=UTF-8 -O2 -std=c++0x -pedantic-errors -Wfatal-errors -Wall -Wextra -Wno-empty-body -Wno-missing-field-initializers -Wwrite-strings -Wno-deprecated -Wno-unused -Wno-non-virtual-dtor -Wno-variadic-macros -fno-diagnostics-show-option -fno-use-linker-plugin -fmessage-length=0 -ftemplate-depth-128 -fno-merge-constants -fno-nonansi-builtins -fno-gnu-keywords -fno-elide-constructors -fstrict-aliasing -fstack-protector-all -Winvalid-pch -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_GLIBCXX_CONCEPT_CHECKS"
 LINK_FLAGS="prelude.a -lmcheck"

--- a/src/CompileConfig.hs
+++ b/src/CompileConfig.hs
@@ -11,7 +11,7 @@ import Prelude hiding ((.))
 import Prelude.Unicode
 import Util (readFileNow, (.))
 
-data CompileConfig = CompileConfig { gxxPath :: FilePath, compileFlags, linkFlags :: [String] }
+data CompileConfig = CompileConfig { gxxPath :: FilePath, objectFiles, compileFlags, linkFlags :: [String] }
 
 readCompileConfig :: IO CompileConfig
 readCompileConfig = do
@@ -19,7 +19,7 @@ readCompileConfig = do
   let
     m = Map.fromList $ Maybe.catMaybes $ (uncurry parseLine .) $ zip [1..] l
     var k = maybe (fail $ "Missing variable in " ++ file ++ ": " ++ k) return (Map.lookup k m)
-  CompileConfig . var "GXX" <*> (words . var "COMPILE_FLAGS") <*> (words . var "LINK_FLAGS")
+  CompileConfig . var "GXX" <*> (words . var "OBJECT_FILES") <*> (words . var "COMPILE_FLAGS") <*> (words . var "LINK_FLAGS")
  where
   file = "compile-config"
   parseLine :: Int → String → Maybe (String, String)

--- a/src/Mkrt.hs
+++ b/src/Mkrt.hs
@@ -47,6 +47,7 @@ ldd f = do
 compiler_files :: IO [FilePath]
 compiler_files = (nub .) $ do
   gxx ← gxxPath . readCompileConfig
+  l ← objectFiles . readCompileConfig
   let
     query_gxx q = do
       (status, out, err) ← readProcessWithExitCode gxx [q] ""
@@ -62,7 +63,6 @@ compiler_files = (nub .) $ do
       Just f → (f:) . ldd f
   gxxlibs ← ldd gxx
   return $ gxx : gxxlibs ++ fs ++ fs'
- where l = words "crt1.o crti.o crtn.o crtbegin.o crtend.o libgcc.a libgcc_s.so libstdc++.so libstdc++.so.6 libmcheck.a libc.so libc_nonshared.a libm.so libm.so.6 libc.so.6 libgcc_s.so.1"
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Make it possible to configure the object files instead of hard-coding them in the source code. This is particularly useful for users who want to add support for external libraries. For example, running geordi with qt5 support requires a bunch of additional object files, such as libpthread, libicu etc.
