### PR TITLE
Do not include <linux/ptrace.h>

### DIFF
--- a/src/Ptrace.hsc
+++ b/src/Ptrace.hsc
@@ -7,7 +7,6 @@ import Control.Monad (when)
 import Prelude
 
 #include <sys/ptrace.h>
-#include <linux/ptrace.h>
 #include <syscall.h>
 
 foreign import ccall "sys/ptrace.h ptrace" c_ptrace :: CInt → CPid → CLong → CLong → IO CLong


### PR DESCRIPTION
&lt;linux/ptrace.h&gt; conflicts with &lt;sys/ptrace.h&gt; on recent
toolchains and including the latter is enough.

```
In file included from Ptrace.hsc:10:0:
/usr/include/linux/ptrace.h:58:8: error:
redefinition of ‘struct ptrace_peeksiginfo_args’
 struct ptrace_peeksiginfo_args {
        ^
In file included from Ptrace.hsc:9:0:
/usr/include/sys/ptrace.h:191:8: note: originally defined here
 struct ptrace_peeksiginfo_args
        ^
```
