### PR TITLE
Prelude: cleanup compile warnings about unused variables

### DIFF
--- a/prelude/tracked.cpp
+++ b/prelude/tracked.cpp
@@ -63,7 +63,7 @@ namespace tracked
       error()() << "tried to " << s << (e->status == pillaged ? " pillaged " : " destructed ") << *e << '.';
     }
 
-    void * op_new(std::size_t const s, bool const array, void * const r, char const * const name) {
+    void * op_new(std::size_t const, bool const array, void * const r, char const * const name) {
       if (!r) return 0;
       info()() << "new(" << name << (array ? "[]" : "") << ")";
       return r;

--- a/prelude/type_strings.hpp
+++ b/prelude/type_strings.hpp
@@ -225,7 +225,7 @@ namespace textual_type_descriptions
       v.push_back(an_or_count<T>(N)); group_list_desc<tlists::tlist<U...> >::s(v);
   } };
 
-  template <> struct group_list_desc<tlists::tlist<> > { static void s (std::vector<std::string> & v) {} };
+  template <> struct group_list_desc<tlists::tlist<> > { static void s (std::vector<std::string> &) {} };
 
   template <typename... T>
   struct list_desc: group_list_desc<typename tlists::group_successive<T...>::type> {};


### PR DESCRIPTION
Harmless warnings, but this unnecessary noise hurts my eyes... :)

```
tracked.cpp:66:37: warning: unused parameter ‘s’
     void * op_new(std::size_t const s, bool const array, void * const r, char const * const name) {
                                     ^
In file included from prelude/prelude.hpp:14:0:
prelude/type_strings.hpp:228:100: warning: unused parameter ‘v’
   template <> struct group_list_desc<tlists::tlist<> > { static void s (std::vector<std::string> & v) {} };
                                                                                                    ^
```
