### PR TITLE
Constrained irc version to < 0.6.0.0

### DIFF
--- a/geordi.cabal
+++ b/geordi.cabal
@@ -54,7 +54,7 @@ executable geordi-irc
     other-modules: Sys, EvalCxx, Flock
     ghc-options: -Wall -fno-warn-unused-binds -fno-warn-unused-do-bind -fno-warn-orphans -O0
     build-tools: hsc2hs
-    build-depends: base>=4, deepseq, mtl >= 2.0.1.0, syb, unix, utf8-string, network, containers, parsec, Diff, directory, regex-compat, irc, bytestring, base-unicode-symbols>=0.1.4, setops>=0.1, streams>=0.7, semigroups>=0.5, pointed>=0.1.3, setlocale, process>=1.2.0.0
+    build-depends: base>=4, deepseq, mtl >= 2.0.1.0, syb, unix, utf8-string, network, containers, parsec, Diff, directory, regex-compat, irc<0.6.0.0, bytestring, base-unicode-symbols>=0.1.4, setops>=0.1, streams>=0.7, semigroups>=0.5, pointed>=0.1.3, setlocale, process>=1.2.0.0
     hs-source-dirs: src
   else
     buildable: False


### PR DESCRIPTION
Upstream has changed from String to ByteString on various functions,
until geordi is updated to use this new change it should be constrained
to the older version in order to build properly.
