### PR TITLE
clean up after build

### DIFF
--- a/install-clang
+++ b/install-clang
@@ -16,3 +16,5 @@ cd /llvm.build
 /llvm/configure --enable-optimized --disable-assertions --enable-targets=x86_64 --disable-docs --disable-terminfo --disable-libedit --disable-backtraces --disable-jit
 make -j2
 make install
+
+rm -rf /llvm /llvm.build

--- a/install-haskell
+++ b/install-haskell
@@ -5,3 +5,7 @@ cd /
 wget https://haskell.org/platform/download/7.10.2/haskell-platform-7.10.2-a-unknown-linux-deb7.tar.gz
 tar xf haskell-platform-7.10.2-a-unknown-linux-deb7.tar.gz
 ./install-haskell-platform.sh
+
+rm install-haskell-platform.sh
+rm hp-usr-local.tar.gz
+rm haskell-platform-7.10.2-a-unknown-linux-deb7.tar.gz

--- a/install-klee
+++ b/install-klee
@@ -30,3 +30,5 @@ cd klee
 ./configure --with-stp=/usr/local --with-llvmobj=/llvm.build --with-llvmsrc=/llvm --enable-posix-runtime
 make ENABLE_OPTIMIZED=1
 make install
+
+rm -rf /minisat /stp /klee-uclibc /klee


### PR DESCRIPTION
Reduces final image size from 6GB to 4GB. Could probably be reduced to 2-3, but with much more effort than this.