### PR TITLE
Use CMake instead of autoconf for compiling llvm.

### DIFF
--- a/install-clang
+++ b/install-clang
@@ -13,7 +13,7 @@ patch -p0 < /geordi/src/llvm-no-temp-files.patch
 
 mkdir /llvm.build
 cd /llvm.build
-/llvm/configure --enable-optimized --disable-assertions --enable-targets=x86_64 --disable-docs --disable-terminfo --disable-libedit --disable-backtraces --disable-jit
+cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_BUILD_DOCS=OFF /llvm
 make -j2
 make install
 


### PR DESCRIPTION
The autoconf build system is removed in llvm 3.9.