### PR TITLE
Use nproc to determine jobs used to build GCC/Clang.

### DIFF
--- a/install-clang
+++ b/install-clang
@@ -15,7 +15,7 @@ patch -p0 < /geordi/src/llvm-no-temp-files.patch
 mkdir /llvm.build
 cd /llvm.build
 cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_BUILD_DOCS=OFF -DLIBCXX_CXX_ABI=libstdc++ /llvm
-make -j2
+make -j`nproc`
 make install
 make install-cxx
 

--- a/install-gcc-trunk
+++ b/install-gcc-trunk
@@ -6,6 +6,6 @@ svn checkout svn://gcc.gnu.org/svn/gcc/trunk gcc-trunk
 mkdir gcc-trunk.build
 cd gcc-trunk.build
 /gcc-trunk/configure --disable-multilib --enable-languages=c,c++ --disable-bootstrap --disable-libgomp --enable-checking=no --disable-checking --disable-decimal-float
-make -j2
+make -j`nproc`
 make install
 rm -rf /gcc-trunk /gcc-trunk.build


### PR DESCRIPTION
The initial build of the docker container is slowed down by the fact it only uses two threads.
However, if the machine supports more than 2 threads, they should be used by default.